### PR TITLE
Fix issues where "ObjectPattern" rules do not match

### DIFF
--- a/src/ExhaustiveDeps.ts
+++ b/src/ExhaustiveDeps.ts
@@ -480,7 +480,7 @@ const rule = {
             const property = id.properties.find(
               (p): p is AssignmentProperty => {
                 if (p.type === "Property") {
-                  return p.key === resolved.identifiers[0];
+                  return p.value === resolved.identifiers[0];
                 } else {
                   // p.type === "RestElement"
                   return false;


### PR DESCRIPTION
I am pretty sure the identity check between the variable being checked and its definition should be via `property.value` of the `ObjectPattern` node and not with `property.key`. (At least) under eslint v9.23.0, the resolved identifier only matches `property.value`, but not `property.key`.

<details>
<summary>Example:</summary>

```js
const useStateWithInitial = (initialValue) => {
  const [value, setValue] = useState(initialValue)

  const initialRef = useRef(null)
  if (initialRef.current === null) initialRef.current = initialValue

  const resetValue = useCallback(() => {
    setValue(initialRef.current)
  }, [])

  return { value, setValue, resetValue }
}

function MyComponent() {
  const { value, setValue, resetValue } = useStateWithInitial("ABC")

  const { value: secondValue, setValue: setSecondValue, resetValue: resetSecondValue } = useStateWithInitial("DEF")

  useEffect(() => {
    if (value.length > 100) resetValue()
  }, [value])

  useEffect(() => {
    if (secondValue.length > 200) resetSecondValue()
  }, [secondValue])

  return (
    <div>
      <span>{value}</span>
      <button onClick={() => setValue((old) => old + "123"}>Update</button>
      <button onClick={resetValue}>Reset</button>

      <span>{secondValue}</span>
      <button onClick={() => setSecondValue((old) => old + "456789"}>Update</button>
      <button onClick={resetSecondValue}>Reset</button>
    </div>
  )
}
```

With a configuration of:
```js
  staticHooks: {
    useStateWithInitial: { setValue: true, resetValue: true },
  }
```

This example could be simplified by using arrays instead of objects, but in my project using objects makes it easier to extract only the required items.

</details>