### PR TITLE
Remove experimental gating for useEffectEvent rules

### DIFF
--- a/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -7675,61 +7675,59 @@ const tests = {
   ],
 };
 
-if (__EXPERIMENTAL__) {
-  tests.valid = [
-    ...tests.valid,
-    {
-      code: normalizeIndent`
-        function MyComponent({ theme }) {
-          const onStuff = useEffectEvent(() => {
-            showNotification(theme);
-          });
-          useEffect(() => {
-            onStuff();
-          }, []);
-        }
-      `,
-    },
-  ];
+tests.valid = [
+  ...tests.valid,
+  {
+    code: normalizeIndent`
+      function MyComponent({ theme }) {
+        const onStuff = useEffectEvent(() => {
+          showNotification(theme);
+        });
+        useEffect(() => {
+          onStuff();
+        }, []);
+      }
+    `,
+  },
+];
 
-  tests.invalid = [
-    ...tests.invalid,
-    {
-      code: normalizeIndent`
-        function MyComponent({ theme }) {
-          const onStuff = useEffectEvent(() => {
-            showNotification(theme);
-          });
-          useEffect(() => {
-            onStuff();
-          }, [onStuff]);
-        }
-      `,
-      errors: [
-        {
-          message:
-            "Functions returned from `useEffectEvent` must not be included in the dependency array. " +
-            "Remove `onStuff` from the list.",
-          suggestions: [
-            {
-              desc: "Remove the dependency `onStuff`",
-              output: normalizeIndent`
-                function MyComponent({ theme }) {
-                  const onStuff = useEffectEvent(() => {
-                    showNotification(theme);
-                  });
-                  useEffect(() => {
-                    onStuff();
-                  }, []);
-                }
-              `,
-            },
-          ],
-        },
-      ],
-    },
-  ];
-}
+tests.invalid = [
+  ...tests.invalid,
+  {
+    code: normalizeIndent`
+      function MyComponent({ theme }) {
+        const onStuff = useEffectEvent(() => {
+          showNotification(theme);
+        });
+        useEffect(() => {
+          onStuff();
+        }, [onStuff]);
+      }
+    `,
+    errors: [
+      {
+        message:
+          "Functions returned from `useEffectEvent` must not be included in the dependency array. " +
+          "Remove `onStuff` from the list.",
+        suggestions: [
+          {
+            desc: "Remove the dependency `onStuff`",
+            output: normalizeIndent`
+              function MyComponent({ theme }) {
+                const onStuff = useEffectEvent(() => {
+                  showNotification(theme);
+                });
+                useEffect(() => {
+                  onStuff();
+                }, []);
+              }
+            `,
+          },
+        ],
+      },
+    ],
+  },
+];
 
 // Tests that are only valid/invalid across parsers supporting Flow
 const testsFlow = {

--- a/src/ExhaustiveDeps.ts
+++ b/src/ExhaustiveDeps.ts
@@ -2188,10 +2188,7 @@ function isAncestorNodeOf(a: Node, b: Node): boolean {
 }
 
 function isUseEffectEventIdentifier(node: Node): boolean {
-  if (__EXPERIMENTAL__) {
-    return node.type === "Identifier" && node.name === "useEffectEvent";
-  }
-  return false;
+  return node.type === "Identifier" && node.name === "useEffectEvent";
 }
 
 function getUnknownDependenciesMessage(reactiveHookName: string): string {


### PR DESCRIPTION
React 19.2 made the `useEffectEvent` hook stable. I think we can follow upstream (https://github.com/facebook/react/pull/34660) and remove the feature gate here as well.