### PR TITLE
Bump eslint peer dependency to include v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/wogns3623/eslint-plugin-better-exhaustive-deps",
   "peerDependencies": {
-    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.11.4",
@@ -46,7 +46,7 @@
     "@typescript-eslint/parser-v3": "npm:@typescript-eslint/parser@^3.10.0",
     "@typescript-eslint/parser-v4": "npm:@typescript-eslint/parser@^4.1.0",
     "@typescript-eslint/parser-v5": "npm:@typescript-eslint/parser@^5.62.0",
-    "@types/eslint-v8": "npm:@types/eslint@^8.56.12",
+    "@types/eslint": "^9.6.1",
     "@types/estree": "^1.0.6",
     "@types/estree-jsx": "^1.0.5",
     "@types/node": "^20.2.5",


### PR DESCRIPTION
As peer upstream: https://github.com/facebook/react/pull/35720

> ESLint v10.0.0 was released on February 7, 2026. The current `peerDependencies` for `eslint-plugin-react-hooks` only allows up to `^9.0.0`, which causes peer dependency warnings when installing with ESLint v10.
> 
> This PR:
> 
> - Adds ^10.0.0 to the eslint peer dependency range
> - Adds eslint-v10 to devDependencies for testing
> - Adds an eslint-v10 e2e fixture (based on the existing eslint-v9 fixture)
> 
> ESLint v10's main breaking changes (removal of legacy eslintrc config, deprecated context methods) don't affect this plugin - flat config is already supported since v7.0.0, and the deprecated APIs already have fallbacks in place.